### PR TITLE
Fix GitHub Actions apt lock conflicts

### DIFF
--- a/.github/workflows/c-sdk-build.yml
+++ b/.github/workflows/c-sdk-build.yml
@@ -12,6 +12,7 @@ jobs:
     name: Build C SDK Libraries
     runs-on: [self-hosted, linux, arm64, docker]
     strategy:
+      max-parallel: 1
       matrix:
         os: [linux]
         arch: [x64, arm64]
@@ -157,6 +158,7 @@ jobs:
   build-documentation:
     name: Generate documentation
     runs-on: [self-hosted, linux, arm64, docker]
+    needs: build-packages
     
     steps:
       - name: Checkout repository

--- a/.github/workflows/c-sdk-test.yml
+++ b/.github/workflows/c-sdk-test.yml
@@ -12,6 +12,7 @@ jobs:
     name: Test C SDK
     runs-on: [self-hosted, linux, arm64, docker]
     strategy:
+      max-parallel: 1
       matrix:
         os: [linux]
         compiler: [gcc, clang]
@@ -97,6 +98,7 @@ jobs:
   valgrind-test:
     name: Memory leak detection
     runs-on: [self-hosted, linux, arm64, docker]
+    needs: test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -122,7 +124,9 @@ jobs:
   cross-compile:
     name: Cross compilation test
     runs-on: [self-hosted, linux, arm64, docker]
+    needs: valgrind-test
     strategy:
+      max-parallel: 1
       matrix:
         target: [aarch64-linux-gnu, arm-linux-gnueabihf]
     
@@ -153,6 +157,7 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: [self-hosted, linux, arm64, docker]
+    needs: cross-compile
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
Multiple parallel jobs were trying to run apt-get simultaneously on self-hosted runners, causing dpkg frontend lock conflicts and workflow failures.

## Solution
- Added `max-parallel: 1` to matrix strategies to prevent simultaneous package installations
- Added job dependencies (`needs`) to serialize execution where appropriate
- This ensures only one job installs packages at a time, eliminating lock conflicts

## Testing
- Fixes tested on workflows that were failing with 'Could not get lock /var/lib/dpkg/lock-frontend' errors
- All workflow files updated: c-sdk-test.yml and c-sdk-build.yml

Fixes: GitHub Actions workflow failures