### PR TITLE
Add comprehensive apt lock cleanup to prevent workflow failures

### DIFF
--- a/.github/workflows/c-sdk-build.yml
+++ b/.github/workflows/c-sdk-build.yml
@@ -24,12 +24,26 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential
 
       - name: Install ARM64 cross-compilation tools
         if: matrix.arch == 'arm64'
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Build static library
@@ -110,6 +124,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential tar gzip
 
@@ -166,6 +187,13 @@ jobs:
 
       - name: Install Doxygen
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz
 

--- a/.github/workflows/c-sdk-test.yml
+++ b/.github/workflows/c-sdk-test.yml
@@ -32,6 +32,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential clang
 
@@ -105,6 +112,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential clang valgrind
 
@@ -136,6 +150,13 @@ jobs:
 
       - name: Install cross-compilation tools
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get update
           sudo apt-get install -y gcc-${{ matrix.target }}
 
@@ -164,6 +185,13 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # Wait for any existing apt processes to complete and clean up locks
+          sudo fuser -vki /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || true
+          sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
+          sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
+          sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential clang gcovr
 


### PR DESCRIPTION
## Problem
Even after adding job serialization, some workflows were still failing with apt lock conflicts, likely due to background processes or stale locks from previous runs.

## Solution
Added comprehensive apt lock cleanup steps to all package installation tasks:
- Use `fuser` to kill any existing apt processes
- Remove stale lock files
- Run `dpkg --configure -a` to ensure clean package manager state
- Apply to all apt operations: dependencies, cross-compilation tools, and Doxygen

## Testing
This should resolve persistent apt lock conflicts on self-hosted runners where background processes might interfere with package installation.

## Files Changed
- `.github/workflows/c-sdk-test.yml`: Added cleanup to dependency and cross-compilation tool installation
- `.github/workflows/c-sdk-build.yml`: Added cleanup to dependency, ARM64 tools, and Doxygen installation

Fixes persistent apt lock issues preventing successful workflow execution.