### PR TITLE
Fix broken package dependencies on self-hosted runners

### DIFF
--- a/.github/workflows/c-sdk-build.yml
+++ b/.github/workflows/c-sdk-build.yml
@@ -29,7 +29,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential
@@ -42,7 +46,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
@@ -129,7 +137,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential tar gzip
@@ -192,7 +204,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz

--- a/.github/workflows/c-sdk-test.yml
+++ b/.github/workflows/c-sdk-test.yml
@@ -37,7 +37,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential clang
@@ -117,7 +121,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential clang valgrind
@@ -155,7 +163,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get update
           sudo apt-get install -y gcc-${{ matrix.target }}
@@ -190,7 +202,11 @@ jobs:
           sudo fuser -vki /var/cache/apt/archives/lock >/dev/null 2>&1 || true
           sudo fuser -vki /var/lib/apt/lists/lock >/dev/null 2>&1 || true
           sudo rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock /var/lib/dpkg/lock* >/dev/null 2>&1 || true
-          sudo dpkg --configure -a >/dev/null 2>&1 || true
+          
+          # Fix any broken package dependencies
+          sudo dpkg --configure -a || true
+          sudo apt-get update --fix-missing || true
+          sudo apt-get install -f || true
           
           sudo apt-get update
           sudo apt-get install -y uuid-dev build-essential clang gcovr


### PR DESCRIPTION
## Problem
After resolving apt lock conflicts, workflows were failing due to broken package dependencies on the self-hosted runners. Specifically:
- python3-jinja2 depends on python3-babel
- gcovr depends on python3-jinja2
- Package configuration was incomplete

## Solution
Enhanced the dependency resolution process:
- Run `dpkg --configure -a` without output redirection to see issues
- Add `apt-get update --fix-missing` to handle missing packages
- Add `apt-get install -f` to fix broken dependencies
- Apply comprehensive dependency fixing before all package installations

## Files Changed
- `.github/workflows/c-sdk-test.yml`: Enhanced dependency resolution for all apt operations
- `.github/workflows/c-sdk-build.yml": Enhanced dependency resolution for all apt operations

This should resolve the python3-jinja2, python3-babel, and gcovr dependency issues that were preventing successful package installation.